### PR TITLE
Add `draw_delay` option for all objects to delay spawn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,7 @@ export class SatellitesLayer
       this.globe.getCoords(
         object.lat,
         object.lon,
-        // heightOffset returns a value in world units, but getCoords works with globe radius units
-        object.heightOffset() / DEFAULT_GLOBE_RADIUS,
+        object.heightOffset(),
       ),
     );
   }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Once a JSON websocket stream is successfully ingested, any fields in the JSON wi
 
 There are values that can be added to the URL for auto-connection and first-view behaviors: websocketUsername (string of username), websocketPassword (string of password, unencrypted), and autoconnect (true/false), startupZoom (how far to zoom the map) and startupLat/startupLon.
 
-The "explosion" event type has 20km randomization of placement, in order to effectively show activity in areas which have many events that happen with the same lat/lon coordinates. 
-
-There is a slight randomized delay built in to events being placed on the map to "smooth" events across time. This was due to websocket buffers emptying quickly, which caused bursty behaviors and unpleasing rendering. This probably should be made into an optional smoothing mechanism but is currently hard-coded.
+The "explosion" event type has 20km randomization of placement, in order to effectively show activity in areas which have many events that happen with the same lat/lon coordinates.
 
 Events with 0,0 as lat/lon are not shown.
 
@@ -79,6 +77,7 @@ Data that is expected from websocket (or file downloads) is defined in [service/
 | type                               | explosion                                         | Type of the event (explosion, circle, pointer, bar, downloaded, arc)                                                                                 |
 | ttl                                | 15000 (explosion), 5000 (arc), Infinity otherwise | How long the item should be visible on the map                                                                                                       |
 | fade_duration                      | -                                                 | Fade period at the end of object lifetime                                                                                                            |
+| draw_delay                         | -                                                 | Delay the drawing of this object in ms. Can be useful to add random delays, or to precisely control objects display time                             |
 | opacity                            | 100                                               | Object opacity (0-100). This can be further modified with global opacity slider and per layer opacity sliders                                        |
 | layer_id                           | -                                                 | Assigns this object to a specific layer (number id). All layers can be controlled in settings, by subtracting opacity from all objects in the layer  |
 | layer_name                         | -                                                 | If defined, sets a name for this layer in the settings dialog.                                                                                       |
@@ -180,7 +179,7 @@ sources:
           counter=$$(shuf -i 1-30 -n 1);
           echo "{\"lat\": $$lat, \"lon\": $$lon, \"pop\": \"$$pop\", \"country\": \"$$country\", \"counter\": $$counter}";
         done
-                
+
 enrichment_tables:
   globe_access:
     type: "file"
@@ -198,7 +197,7 @@ transforms:
     inputs: ["random_json"]
     source: |
       . = parse_json!(.message)
-      
+
 sinks:
   websocket_sink_5007:
     inputs: ["parse_message"]

--- a/src/data/arc.ts
+++ b/src/data/arc.ts
@@ -124,20 +124,14 @@ export class ArcData
         ttl: this.total_lifetime - (this.arc_draw_duration ?? 200),
         fade_duration: this.fade_duration,
         always_faces_viewer: this.always_faces_viewer,
+        draw_delay: this.lifetime < 0 ? -this.lifetime : null,
         ...this.additional_data,
       },
     );
   }
 
   clone(): ArcData {
-    const new_data = new ArcData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
-    });
+    const new_data = new ArcData(this.cloneData());
     return new_data;
   }
 }
@@ -177,14 +171,11 @@ export class ArcLabel
   }
 
   clone(): ArcLabel {
-    const new_data = new ArcLabel(this.defaultHeight, this.startTime, {
-      ...this.additional_data,
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-    });
+    const new_data = new ArcLabel(
+      this.defaultHeight,
+      this.startTime,
+      this.cloneData(),
+    );
     return new_data;
   }
 }

--- a/src/data/bar.ts
+++ b/src/data/bar.ts
@@ -77,14 +77,7 @@ export class BarData
   }
 
   clone(): BarData {
-    const new_data = new BarData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
-    });
+    const new_data = new BarData(this.cloneData());
     return new_data;
   }
 

--- a/src/data/circle.ts
+++ b/src/data/circle.ts
@@ -73,14 +73,7 @@ export class CircleData
   }
 
   clone(): CircleData {
-    const new_data = new CircleData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
-    });
+    const new_data = new CircleData(this.cloneData());
     return new_data;
   }
 }

--- a/src/data/downloaded.ts
+++ b/src/data/downloaded.ts
@@ -62,14 +62,7 @@ export class DownloadedData
   }
 
   clone(): DownloadedData {
-    const new_data = new DownloadedData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
-    });
+    const new_data = new DownloadedData(this.cloneData());
     return new_data;
   }
 

--- a/src/data/explosion.ts
+++ b/src/data/explosion.ts
@@ -14,7 +14,6 @@ import {
 import { CommonData } from "./common";
 import { LifetimeData, PositionData } from "../service/data";
 
-const MAX_SPAWN_DELAY_MS = 5000;
 const RANDOM_OFFSET_MAX_KM = 20;
 
 const DEFAULT_INFLATION_LIFETIME_PERCENTAGE = 0.02;
@@ -182,16 +181,6 @@ export class ExplosionData
     return this;
   }
 
-  /**
-   * Randomizes the startTime of the explosion up to 5 seconds in the future, to prevent explosion spikes.
-   */
-  randomizeSpawnTime(): ExplosionData {
-    const addition = Math.random() * MAX_SPAWN_DELAY_MS;
-    this.startTime += addition;
-    this.lifetime -= addition;
-    return this;
-  }
-
   labelExpired(): boolean {
     return this.lifetime_fraction > this.label_expiry_fraction;
   }
@@ -302,13 +291,8 @@ export class ExplosionData
 
   clone(): ExplosionData {
     const new_data = new ExplosionData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
+      ...this.cloneData(),
       inflation_factor: this.inflation_factor,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
     });
     return new_data;
   }

--- a/src/data/pointer.ts
+++ b/src/data/pointer.ts
@@ -84,14 +84,7 @@ export class PointerData
   }
 
   clone(): PointerData {
-    const new_data = new PointerData({
-      lat: this.lat,
-      lon: this.lon,
-      ttl: this.total_lifetime,
-      fade_duration: this.fade_duration,
-      always_faces_viewer: this.always_faces_viewer,
-      ...this.additional_data,
-    });
+    const new_data = new PointerData(this.cloneData());
     return new_data;
   }
 

--- a/src/globe/layers/arcs.ts
+++ b/src/globe/layers/arcs.ts
@@ -48,6 +48,10 @@ export class ArcsLayer
       .arcEndLng((obj) => (obj as ArcData).point2_lon)
       .arcColor((obj: object) => {
         const arc = obj as ArcData;
+        if (!arc.visible()) {
+          return "rgba(0,0,0,0)";
+        }
+
         const duration = arc.arc_draw_duration ?? 200;
         const factor = arc.lifetime / duration;
         const revFactor = (arc.total_lifetime - arc.lifetime) / duration;
@@ -58,13 +62,13 @@ export class ArcsLayer
                 "#" + ((obj as ArcData).arc_color ?? QUAD9_COLOR).getHexString()
               );
             } else {
-              return "#000000";
+              return "rgba(0,0,0,0)";
             }
           };
         } else if (duration && revFactor < 1) {
           return (t: number) => {
             if (t < 1 - revFactor) {
-              return "#000000";
+              return "rgba(0,0,0,0)";
             } else {
               return (
                 "#" + ((obj as ArcData).arc_color ?? QUAD9_COLOR).getHexString()

--- a/src/globe/layers/customobject.ts
+++ b/src/globe/layers/customobject.ts
@@ -9,7 +9,6 @@ import {
   RegistryHook,
 } from "../layer";
 import { PointData } from "../../data";
-import { DEFAULT_GLOBE_RADIUS } from "../common";
 
 /**
  * Globe layer that draws all objects that need custom implementation (not provided by three-globe).
@@ -75,11 +74,7 @@ export class CustomObjectLayerGroup
         group.visible = false;
         Object.assign(
           group.position,
-          globe.getCoords(
-            p.lat,
-            p.lon,
-            p.heightOffset() / DEFAULT_GLOBE_RADIUS,
-          ),
+          globe.getCoords(p.lat, p.lon, p.heightOffset()),
         );
 
         if (p.faceCamera()) {

--- a/src/globe/layers/explosiondata/index.ts
+++ b/src/globe/layers/explosiondata/index.ts
@@ -54,9 +54,7 @@ export class ExplosionDataLayerGroup
   takeNewPoint(point: PointData): void {
     // Since explosions are randomized, it makes no sense to replace them if same lat/lon is found
     // Instead, sort by time left, for quicker filtering
-    const explosion = (point as ExplosionData)
-      .randomizeLocation()
-      .randomizeSpawnTime();
+    const explosion = (point as ExplosionData).randomizeLocation();
     binarySearchReplace(this.data, explosion, compareTimeLeft, {
       noReplace: true,
     });

--- a/src/service/data.ts
+++ b/src/service/data.ts
@@ -26,6 +26,7 @@ const COMMON_NON_FILTER_KEYS = [
   "lon",
   "ttl",
   "fade_duration",
+  "draw_delay",
   "opacity",
   "counter",
   "counter_include",
@@ -103,6 +104,7 @@ export type PositionData = {
 export type LifetimeData = {
   ttl: number | null;
   fade_duration: number | null;
+  draw_delay: number | null;
 };
 export type CounterData = {
   counter: number | null;


### PR DESCRIPTION
Previously only "explosion" type supported delayed spawn and it was randomized (up to 5 second delay). It was not possible to control it, it was always on for these objects. This enables an additional parameter which allows specifying exact delay for all object types and removes the randomized spawn time delay for "explosion" type.

Closes: #1